### PR TITLE
New options for reset_env.sh script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ AZAkazam is a development, testing and deployment framework for EOS.IO, aiming t
 
 -----------------------
 ## Setup
-Start by pulling this repo. You can operate in 2 modes: local or containerized. 
+Start by pulling this repo. You can operate in 2 modes: local or containerized.
 Local is geared towards on-premises development, while dockerized is more aimed at CI.
 
 ### Local
-If operating locally: 
+If operating locally:
 * You'll need to have the EOSIO.CDT toolkit installed. You can find the setup instructions here: https://developers.eos.io/eosio-home/v1.7.0/docs/installing-the-contract-development-toolkit
 
-* To use the default hello world test template, you'll need a local Nodeos image. 
-You can set one up with docker by running it with `./reset_env.sh`
+* To use the default hello world test template, you'll need a local Nodeos image.
+You can set one up with docker by running it with `source reset_env.sh -d`
+Or you may use the locally installed instance `source reset_env.sh -l`
 
 * You'll need node v10 - installation instructions can be found here: https://nodejs.org/en/download/package-manager/
 At the root of this repo, run `npm i` to install dependencies
@@ -43,7 +44,7 @@ Getting your project up and running is fairly simple - here are the files you'll
 |-> package.json: you may change the name of the default template there
 |-> templates: A directory to save your [deployment templates](#Templates)
 |-> src: The directory to save the sources of your smart contracts
-|-> tests: The directory to save your Mocha test 
+|-> tests: The directory to save your Mocha test
 
 ## Templates
 The template files are YAML descriptors aimed at managing the deployments of the contracts. The `default.yml` should get your started.
@@ -64,10 +65,10 @@ Tests come with a handy helper:
 `global.EOSContract.getPrivateKey("active@azarusiocorp")` will retrieve the private key for a permission/account
 ```
  global.EOSContract.sendAction(
-      'hello', 
-      'hi', 
-      {user: "bob"}, 
-      "active@azarusiocorp", 
+      'hello',
+      'hi',
+      {user: "bob"},
+      "active@azarusiocorp",
       global.EOSContract.getPrivateKey("active@azarusiocorp")
       )
 ```

--- a/reset_env.sh
+++ b/reset_env.sh
@@ -1,23 +1,89 @@
 #!/bin/sh
-docker stop eosio
-docker rm -f eosio
 
-docker pull eosio/eos:v1.5.0
+# Variables
+DataDIR=/tmp/data
+ConfigDIR=/tmp/config
+LogFile=/tmp/nodeos.log
 
-echo "> Starting a fresh nodeos"
-if grep -q Microsoft /proc/version; then
-  dir="$(where.exe README.md  | sed 's=\\=\\\\=g'| sed 's/README.md/\src\:\/home\/src/' | sed 's/\r//')"
-  echo "Ubuntu on Windows: $dir"
-else
-  dir="`pwd`/src:/home/src"
-  echo "native Linux: $dir"
-fi
+# Show script info when launched
+InfoMessage() {
+	echo "> Starting a fresh nodeos"
+	if grep -q Microsoft /proc/version; then
+		dir="$(where.exe README.md  | sed 's=\\=\\\\=g'| sed 's/README.md/\src\:\/home\/src/' | sed 's/\r//')"
+		echo "Ubuntu on Windows: $dir"
+	else
+		dir="`pwd`/src:/home/src"
+		echo "native Linux: $dir"
+	fi
+}
 
+# Remove data and configuration files are used by local nodeos (not docker version)
+RemoveLocalFiles() {
+	rm -fr $DataDIR
+	rm -fr $ConfigDIR
+	rm -f $LogFile
+}
 
-docker run --name eosio \
-  --publish 7777:7777 \
-  --volume "${dir}" \
-  --detach \
-  eosio/eos:v1.5.0 \
-  /bin/bash -c \
-  "keosd --http-server-address=0.0.0.0:5555 & exec nodeos -e -p eosio --plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::history_plugin --plugin eosio::history_api_plugin --plugin eosio::http_plugin -d /mnt/dev/data --config-dir /mnt/dev/config --http-server-address=0.0.0.0:7777 --access-control-allow-origin=* --contracts-console --http-validate-host=false --filter-on='*'"
+# Run local instance of keosd and nodeos
+RunLocal() {
+
+	# Remove local files before go further
+	RemoveLocalFiles
+
+	# Kill already running keosd
+	pkill keosd
+
+	# Kill already running nodeos
+	pkill nodeos
+
+	# Start a new instance of keosd
+	keosd --http-server-address=0.0.0.0:5555 &
+
+	# Start a new instance of nodeos
+	nodeos -e -p eosio \
+	--plugin eosio::producer_plugin \
+	--plugin eosio::chain_api_plugin \
+	--plugin eosio::http_plugin \
+	--plugin eosio::history_plugin \
+	--plugin eosio::history_api_plugin \
+	--data-dir $DataDIR \
+	--config-dir $ConfigDIR/tmp/config \
+	--access-control-allow-origin=* \
+	--contracts-console \
+	--http-validate-host=false \
+	--http-server-address=0.0.0.0:7777 \
+	--filter-on='*' >> $LogFile 2>&1 &
+}
+
+# Run docker instance of keosd and nodeos
+RunDocked() {
+
+	# Stop running eosio docker container
+	docker stop eosio
+
+	# Remove eosio docker container
+	docker rm -f eosio
+
+	# Pull eosio image or a repository from a registry
+	docker pull eosio/eos:v1.5.0
+
+	# Run keosd and nodeos inside the docker environment
+	docker run --name eosio \
+	  --publish 7777:7777 \
+	  --volume "${dir}" \
+	  --detach \
+	  eosio/eos:v1.5.0 \
+	  /bin/bash -c \
+	  "keosd --http-server-address=0.0.0.0:5555 & exec nodeos -e -p eosio --plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::history_plugin --plugin eosio::history_api_plugin --plugin eosio::http_plugin -d /mnt/dev/data --config-dir /mnt/dev/config --http-server-address=0.0.0.0:7777 --access-control-allow-origin=* --contracts-console --http-validate-host=false --filter-on='*'"
+}
+
+# Show program info message
+InfoMessage
+
+# Restart keosd and nodeos using local instance or docked instance
+while getopts "ld" opts; do
+	case ${opts} in
+		l) RunLocal ;;
+		d) RunDocked ;;
+	esac
+done


### PR DESCRIPTION
Default 'reset_env.sh' shell script restarts only Dockerized version of 'keosd' and 'nodeos'. The new one can also operates with locally installed eosio version.
It adds additional options, which specify what instance to restart.
'-l' means local instance
'-d' means Dockerized version
The script should be launched inside current bash session. Use 'source' keyword preceding the script name.
New syntax for full command will looks like `source reset_env.sh -l` to restart local version or `source reset_env.sh -d` to restart the Dockerized version.